### PR TITLE
Remove console logs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,14 +21,12 @@ module.exports = {
         // set headers
         setHeaders.forEach(({ key, value }) => {
           requestContext.response.http.headers.append(key, value);
-          console.debug("set header " + key + ": " + value);
         });
 
         // set cookies
         setCookies.forEach(({ name, value, options }) => {
           var cookieString = cookie.serialize(name, value, options);
           requestContext.response.http.headers.set("Set-Cookie", cookieString);
-          console.debug("set header Set-Cookie: " + cookieString);
         });
 
         return requestContext;


### PR DESCRIPTION
I've removed the `console.debug` because it's adding a lot of noise in the console. I don't think that every request should log a debugging message.